### PR TITLE
reatached proxy hosts as dockernized hostnames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wordpress/uploads/*
 !.gitkeep
+nohup.out

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     depends_on:
       - wp
       - db
-    ports:
-      - "3000:3000"
     environment:
       HOST: "0.0.0.0"
     volumes:
@@ -26,8 +24,6 @@ services:
       - flat-network
   wp:
     build: ./wordpress
-    ports:
-      - "8080:8080"
     depends_on:
       - db
     environment:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,7 +3,7 @@ server {
     server_name  localhost;
 
     location ~ ^/wp([a-z-_*]) {
-      proxy_pass http://nuxtandwpapi_wp_1:8080;
+      proxy_pass http://wp:8080;
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -11,7 +11,7 @@ server {
     }
 
     location / {
-      proxy_pass http://nuxtandwpapi_nuxt_1:3000;
+      proxy_pass http://nuxt:3000;
       proxy_set_header Host $http_host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -16,7 +16,7 @@ import axios from 'axios'
 
 export default {
   async asyncData ({ isServer }) {
-    const API_ROOT = `${isServer ? 'http://nuxtandwpapi_wp_1:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
+    const API_ROOT = `${isServer ? 'http://wp:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
     let posts = null
 
     try {

--- a/nuxt/pages/posts/:slug.vue
+++ b/nuxt/pages/posts/:slug.vue
@@ -12,7 +12,7 @@ import axios from 'axios'
 export default {
   async asyncData ({ params, isServer, redirect }) {
     const { slug } = params
-    const API_ROOT = `${isServer ? 'http://nuxtandwpapi_wp_1:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
+    const API_ROOT = `${isServer ? 'http://wp:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
     let data = null
 
     try {

--- a/nuxt/pages/posts/index.vue
+++ b/nuxt/pages/posts/index.vue
@@ -16,7 +16,7 @@ import axios from 'axios'
 
 export default {
   async asyncData ({ isServer }) {
-    const API_ROOT = `${isServer ? 'http://nuxtandwpapi_wp_1:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
+    const API_ROOT = `${isServer ? 'http://wp:8080' : 'http://localhost:5000'}/wp-json/wp/v2`
     let posts = null
 
     try {


### PR DESCRIPTION
FYI:

> Containers for the linked service will be reachable at a hostname identical to the alias

ref: https://docs.docker.com/compose/compose-file/#links